### PR TITLE
Add UAR sampling function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,8 @@ sampling_strings:
 sampling_at:
 	gcc examples/sampling/at.c src/sampling/sampling.c src/sampling/helpers.c src/sampling/grammar_hash_table.c src/sampling/key_hash_table.c src/sampling/rule_hash_table.c src/grammar.c -o bin/sampling_at.o
 
+sampling_uar:
+	gcc examples/sampling/sample.c src/sampling/sampling.c src/sampling/helpers.c src/sampling/grammar_hash_table.c src/sampling/key_hash_table.c src/sampling/rule_hash_table.c src/grammar.c -o bin/sample.o
+
 clean:
 	rm -rf bin/*

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -29,7 +29,7 @@ This is a concise reference to help you navigate and utilize the `gfuzztools` C 
 
 ### `unify_key_inv()` – the basic fuzzer
 
- The program simply aims to generates random strings from a given grammar.  The program is reliant on two inputs to run: your `Grammar`, and the `Token` you wish to start fuzzing from.
+The program simply aims to generates random strings from a given grammar. The program is reliant on two inputs to run: your `Grammar`, and the `Token` you wish to start fuzzing from.
 
 1. Initialise your `TokenArray` to store the fuzzed strings:
 ```c
@@ -50,6 +50,8 @@ unify_key_inv(token, &grammar, &fuzzed)
 print_token_array(&fuzzed);
 ```
 
+To ensure randomness of the `rand()` function, ensure to set the seed to the current time by placing `srand((unsigned int)time(NULL));` at the start of your main function.
+
 This is an implementation of [The simplest grammar fuzzer in the world](https://rahul.gopinath.org/post/2019/05/28/simplefuzzer-01/) in C.
 
 > **Try it out!**
@@ -59,7 +61,6 @@ This is an implementation of [The simplest grammar fuzzer in the world](https://
 >
 > You should see three different 8-bit tokens printed to your terminal each time you run the program.
 
-
 ### `key_get_def()`
 
 `key_get_def()` serves as the cornerstone for obtaining the complete definition of a non-terminal or terminal key in the grammar, given a specific string length.
@@ -67,6 +68,29 @@ This is an implementation of [The simplest grammar fuzzer in the world](https://
 You need to run this function in order to use all other functionality in `gfuzztools`. 
 
 #### Set up hash tables
+
+Note: the three hash tables must be defined as global variables for the program to run:
+
+```c
+// Place these lines before your main() function
+KeyHashTable key_strs;
+RuleHashTable rule_strs;
+GrammarHashTable grammar_hash;
+
+// Surround your runner code with the following initialisation and breakdown code in the main() function.
+
+// Setup
+init_key_hash_table(&key_strs);
+init_rule_hash_table(&rule_strs);
+init_grammar_hash_table(&grammar_hash);
+
+# your program code here
+
+// Cleanup
+breakdown_key_hash_table(&key_strs);
+breakdown_rule_hash_table(&rule_strs);
+breakdown_grammar_hash_table(&grammar_hash);
+```
 
 #### Usage
 
@@ -123,7 +147,20 @@ DynTokenArray* string = get_string_at(definition, index);
 ```
 It navigates through the grammar considering both key nodes and rule nodes to pinpoint the desired string.
 
-These functions collectively allow us to efficiently explore and extract valid strings from a grammar.
+### `string_sample_UAR()`
+
+The first major milestone in `gfuzztools`: the ability to uniformly at random sample a string from a grammar.
+
+This function automatically calls the cornerstone function, so the runner code is extremely simple:
+```c
+Token token = ...;
+Grammar grammar = ...;
+size_t l_str = ...;
+
+DynTokenArray* string = string_sample_UAR(token, &grammar, l_str);
+```
+
+You can then use `print_dta()` to print the sampled string. Similar to `unify_key_inv()` ensure the randomness of the `rand()` function by setting its seed based on the current time: place `srand((unsigned int)time(NULL));` at the start of your main function.
 
 ## Structure
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@
 - **Fuzzing Functions:** Generate strings from defined grammars for comprehensive testing and validation.
 - **String Extraction:** Extract all strings from a grammar or retrieve a specific string at a given index.
 - **Speed:** Preliminary testing indicates a 20x speedup compared to the Python implementation.
-- **Future Expansion:** Ongoing work includes implementing functionality for randomly sampling strings from grammars.
+- **UAR sampling:** Sample a string of a certain length from a grammar uniformly at random.
 
 <br>
 
@@ -62,12 +62,11 @@ The original motivation of `gfuzztools` was to set up a toolchain to compare the
 We can then combine these two values using the $\text{F1}$ score:
 $$\text{F1 score} = \frac{2 \times \text{Precision} \times \text{Recall}}{\text{Precision} + \text{Recall}}$$
 
-However, it is key that the generating fuzzer is sampling strings **uniformly at random (UAR)**, otherwise [the measure will not be accurate](https://rahul.gopinath.org/post/2021/07/27/random-sampling-from-context-free-grammar/#random-sampling). Hence, the first milestone in `gfuzztools` is to produce a UAR sampler.
+However, it is key that the generating fuzzer is sampling strings **uniformly at random (UAR)**, otherwise [the measure will not be accurate](https://rahul.gopinath.org/post/2021/07/27/random-sampling-from-context-free-grammar/#random-sampling). Hence, the first milestone in `gfuzztools` was to produce a UAR sampler.
 
 ### Future work
 
 `gfuzztools` is a work-in-progress. There are several improvements and additions yet to come, including:
-- Implementing the UAR sampling function
 - Work in the field of grammar inference, including:
     - Implementing Angluin's L* algorithm in C
 

--- a/examples/sampling/sample.c
+++ b/examples/sampling/sample.c
@@ -114,17 +114,14 @@ GrammarHashTable grammar_hash;
 int main()
 {
     // Setup
+    srand((unsigned int)time(NULL));
     init_key_hash_table(&key_strs);
     init_rule_hash_table(&rule_strs);
     init_grammar_hash_table(&grammar_hash);
 
     // Use
-    size_t l_str = 11;
-    KeyNode* key_node = key_get_def(START_TOKEN, &GRAMMAR, l_str);
-    DynTokenArray* strings = key_extract_strings(key_node);
-
-	printf("Each DTA node represents one string:\n\n");
-    print_list_of_dtas(strings);
+    DynTokenArray* string = string_sample_UAR(0x80, &GRAMMAR, 11);
+    print_dta(string);
 
     // Cleanup
     breakdown_key_hash_table(&key_strs);
@@ -133,4 +130,3 @@ int main()
 
     return 0;
 }
-

--- a/include/sampling/sampling.h
+++ b/include/sampling/sampling.h
@@ -3,6 +3,7 @@
 
 #include "../grammar.h"
 #include "hash.h"
+#include <time.h>
 
 /**
  * @brief Retrieves or computes the definition of a non-terminal or terminal key
@@ -28,6 +29,10 @@
  * 
  * @note It is the responsibility of the caller to free the memory allocated 
  *      for the KeyNode when it is no longer needed.
+ * 
+ * @note This function requires the three hash tables `key_strs`, `rule_strs` 
+ *      and `grammar_hash` to be defined as global variables in the calling 
+ *      program.
  * 
  * @see create_key_node, insert_key, get_key, rules_get_def, free_key_node
  */
@@ -151,6 +156,10 @@ DynTokenArray* rule_extract_strings(RuleNode* rn);
  * @note It is the responsibility of the caller to free the memory allocated 
  *      for the DTA when it is no longer needed.
  * 
+ * @note This function requires the three hash tables `key_strs`, `rule_strs` 
+ *      and `grammar_hash` to be defined as global variables in the calling 
+ *      program.
+ * 
  * @see rule_get_string_at
  */
 DynTokenArray* key_get_string_at(KeyNode* kn, int at);
@@ -180,5 +189,27 @@ DynTokenArray* key_get_string_at(KeyNode* kn, int at);
  * @see key_get_string_at, concat_token_arrs
  */
 DynTokenArray* rule_get_string_at(RuleNode* rn, int at);
+
+/**
+ * Uniformly at random samples a string of length `l_str` from the `grammar` 
+ * starting from the specified `key`.
+ * 
+ * Ensure to set the seed of the rand() function in your calling function using
+ * `srand((unsigned int)time(NULL));` to ensure randomness.
+ * 
+ * @param key The starting key for sampling.
+ * @param grammar Pointer to the Grammar structure.
+ * @param l_str The desired length of the sampled string.
+ * 
+ * @return DynTokenArray* A dynamically allocated single TokenArray representing 
+ *      the sampled string.
+ * 
+ * @see key_get_def, key_get_string_at
+ * 
+ * @note This function requires the three hash tables `key_strs`, `rule_strs` 
+ *      and `grammar_hash` to be defined as global variables in the calling 
+ *      program.
+ */
+DynTokenArray* string_sample_UAR(Token key, Grammar* grammar, size_t l_str);
 
 #endif // SAMPLING.h

--- a/src/sampling/sampling.c
+++ b/src/sampling/sampling.c
@@ -323,3 +323,16 @@ DynTokenArray* rule_get_string_at(RuleNode* rn, int at)
 
     return NULL;
 }
+
+DynTokenArray* string_sample_UAR(Token key, Grammar* grammar, size_t l_str)
+{
+
+    KeyNode* kn = key_get_def(key, grammar, l_str);
+    
+    int at = rand() % kn->count;
+    printf("Extracting string from random index %d\n", at);
+    
+    DynTokenArray* string = key_get_string_at(kn, at);
+
+    return string;
+}


### PR DESCRIPTION
Implemented the UAR sampling function `string_sample_UAR()` to complete the first major milestone of `gfuzztools`. See `examples/sampling/sample.c` for basic usage example of the function.

Fixes #1 